### PR TITLE
Proposal: county-level alerts

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,10 @@ else:
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 
+COUNTY_ALERTS = {
+    # 'FULTON': 'https://example.com',
+}
+
 
 @app.template_filter("commafy")
 def commafy_filter(v):
@@ -112,6 +116,7 @@ def search():
                 city=city,
                 results=records[:25],
                 were_more_records=(len(records) > 25),
+                county_alerts=COUNTY_ALERTS,
             )
 
     logging.info("Invalid request")

--- a/static/styles.css
+++ b/static/styles.css
@@ -172,6 +172,11 @@ img.brand {
   flex: 1;
 }
 
+.county-alert i {
+  vertical-align: middle;
+  color: darkorange;
+}
+
 input {
   text-transform: uppercase;
 }

--- a/templates/res-name.html
+++ b/templates/res-name.html
@@ -21,7 +21,14 @@
           </div>
           <div class="list-text">
             {{record.first}} {{ record.middle or '' }} {{record.last}}<br />
-            {{ record.city }}, {{record.county}} COUNTY<br />
+            {{ record.city }}, {{record.county}} COUNTY
+            <br  />
+            {% if record.county in county_alerts %}
+              <div class="county-alert">
+                <i class="material-icons icon-error">error</i>
+                <a href="{{county_alerts[record.county]}}">County-wide Election Update</a>
+              </div>
+            {% endif %}
             {{ record.friendly_ballot_status(true) }}
           </div>
         </li>


### PR DESCRIPTION
In the final days before the November election, there were news stories about absentee ballot [printing issues](https://www.nbcdfw.com/news/politics/decision-2020/printing-issue-affects-1-3-of-mail-in-ballots-in-tarrant-county-administrator-says/2467392/) and [court challenges to drive-thru ballots](https://www.kvue.com/article/news/politics/vote-texas/harris-county-drive-thru-votes/269-7a1dd1bf-ee3a-4190-9c80-21103b3fe72d) in Texas.  While I was watching TXballot.org mentions on Twitter, some people would reply to these stories telling people to check their ballot on our site, when we did not actually know how the court would rule / whose ballots were counted.

I'm proposing an emergency alert feature (or at least creating the PR to have it available). Results in affected counties would display this message, with a link. This link could be to a static page on this site, VoteAmerica, the county's own website, etc.

<img width="627" alt="Screen Shot 2020-12-16 at 11 48 29 PM" src="https://user-images.githubusercontent.com/643918/102445366-588d6480-3ff9-11eb-9b06-d66b4068a5f5.png">
